### PR TITLE
Update to 4.3.2 (really), to Qt 6.6, examples fix

### DIFF
--- a/io.github.xaos_project.XaoS.yml
+++ b/io.github.xaos_project.XaoS.yml
@@ -1,6 +1,6 @@
 app-id: io.github.xaos_project.XaoS
 runtime: org.kde.Platform
-runtime-version: 6.5
+runtime-version: 6.6
 sdk: org.kde.Sdk
 command: xaos
 rename-icon: xaos
@@ -17,8 +17,10 @@ modules:
     no-make-install: true
     post-install:
       - install -Dm 755 bin/xaos ${FLATPAK_DEST}/bin/xaos
-      - mkdir -p ${FLATPAK_DEST}/share/XaoS/
-      - cp -a examples tutorial catalogs ${FLATPAK_DEST}/share/XaoS/
+      - mkdir -p ${FLATPAK_DEST}/share/XaoS/examples
+      - cp -a tutorial catalogs ${FLATPAK_DEST}/share/XaoS/
+      - find examples -name '*.xpf' -exec cp {} ${FLATPAK_DEST}/share/XaoS/examples \; # flattening folders
+
       - install -Dm 644 xdg/xaos.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/xaos.png
       - install -Dm 644 xdg/*.desktop ${FLATPAK_DEST}/share/applications/xaos.desktop
       - install -Dm 644 xdg/xaos.appdata.xml ${FLATPAK_DEST}/share/metainfo/xaos.appdata.xml
@@ -26,7 +28,6 @@ modules:
       - type: git
         url: https://github.com/xaos-project/XaoS.git
         tag: release-4.3.2
-        commit: 85318a73f076443e234e5e41a8354b4441150c61
         x-checker-data:
           type: git
           tag-pattern: ^release-([\d.]+)$

--- a/io.github.xaos_project.XaoS.yml
+++ b/io.github.xaos_project.XaoS.yml
@@ -27,7 +27,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/xaos-project/XaoS.git
-        tag: release-4.3.2
+        # tag: release-4.3.2
+        commit: a5228226bdd927af9807e0781f946c15477c924c
         x-checker-data:
           type: git
           tag-pattern: ^release-([\d.]+)$


### PR DESCRIPTION
* The previous version was stuck to a former version of XaoS because the commit option was also given and it overrode the tag option. So I removed the commit option.
* The examples folder must be flattened in the installed version.
* Qt 6.6 is the newest supported version, it's suggested upgrading the runtime platform.